### PR TITLE
use first context as the current context

### DIFF
--- a/bin/init-anthos-sample-deployment.env
+++ b/bin/init-anthos-sample-deployment.env
@@ -97,8 +97,13 @@ install_istioctl
 install_nomos
 clone_config_repo
 
-# tutorial helper function to watch nomos sync clusters
+# save context names
 names=($(kubectl config get-contexts -o name))
+
+# use first context by default
+kubectl config use-context "${names[0]}"
+
+# tutorial helper function to watch nomos sync clusters
 function watchmtls {
   watch -n 1 'status=$(nomos status) && printf "%s\n\n" "$status" && printf "cluster1: " && kubectl get destinationrule default -n istio-system --context '${names[0]}' -o yaml | grep "mode: " && printf "cluster2: " && kubectl get destinationrule default -n istio-system --context '${names[1]}' -o yaml | grep "mode: "'
 }


### PR DESCRIPTION
Currently defaults to the second context, but for the tutorial, we want the user to use the first.