### PR TITLE
Update Prerequisite Check Script

### DIFF
--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -55,7 +55,7 @@ function check_iam_policy {
 }
 
 function check_org_policy_is_valid {
-  if ! gcloud beta resource-manager org-policies list --project=$PROJECT_ID; then
+  if ! gcloud beta resource-manager org-policies list --project=$PROJECT_ID >/dev/null 2>&1; then
     echo "WARNING: Unable to verify if the project has any Organization Policies that will prevent the deployment."
     return
   fi

--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 # This script checks that prerequisites exist to ensure that
 # the Anthos Sample Deployment is successfully deployed.
 #
@@ -7,7 +9,6 @@
 # ./asd-prereq-checker.sh
 
 SERVICE_MANAGEMENT_API=servicemanagement.googleapis.com
-
 PROJECT_ID=$(gcloud config get-value project)
 
 DISABLED_SERVICE_MANAGEMENT_API="{
@@ -25,6 +26,11 @@ INVALID_ORG_POLICY_IPFORWARD="{
   'Message': 'An org policy (constraints/compute.vmCanIpForward) exists that will prevent this deployment.  Please try this deployment in a project without this org policy.'
 }"
 
+INVALID_ORG_POLICY_TRUSTED_IMAGES="{
+  'KnownIssueId': 'invalid_org_policy_vmCanIpForward)',
+  'Message': 'An org policy (constraints/compute.trustedImageProjects) exists that will prevent this deployment.  Please try this deployment in a project without this org policy.'
+}"
+
 DEPLOYMENT_ALREADY_EXISTS="{
   'KnownIssueId': 'deployment_already_exists',
   'Message': 'An instance of Anthos Sample Deployment already exists. You must delete the previous deployment before performing another deployment.  https://console.cloud.google.com/dm/deployments?project=$PROJECT_ID '
@@ -35,25 +41,12 @@ INVALID_PROJECT_ID="{
   'Message': 'There is a colon in the project id. Please try this deployment in a project without a colon in the project id.'
 }"
 
-function enable_compute_api {
-  # This is needed to check on the network.
-  {
-    echo "Enabling Compute Engine API...this may take a few minutes."
-    result=$(gcloud services enable compute.googleapis.com)
-  } || {
-    echo
-    echo "FATAL: Please enable Compute API to complete the prerequisites checks.  https://console.cloud.google.com/apis/library/compute.googleapis.com?project=$PROJECT_ID "
-    echo
-    exit 1
-  }
-}
-
 function check_iam_policy {
   # iam.serviceAccounts.create and iam.serviceAccounts.setIamPolicy are the
-  # 2 permissions that need to be in place.  Sufficient to check them by
-  # IAM roles.
-  # the list default is unlimited, no paging
-  result=$(gcloud iam roles list --format=json | grep "name")
+  # 2 required permissions for the user to be able to create
+  # the service account.  Sufficient to check them by IAM roles.
+  account=$(gcloud config list account --format "value(core.account)")
+  result=$(gcloud projects get-iam-policy $PROJECT_ID --flatten="bindings[].members" --format="table(bindings.role)" --filter="bindings.members:$account")
   if [[ "$result" == *"roles/owner"* || "$result" == *"roles/editor"* || "$result" == *"roles/iam.serviceAccountAdmin"* ]]; then
     echo "PASS: User has permission to create service account with the required IAM policies."
   else
@@ -76,6 +69,14 @@ function check_org_policy_is_valid {
   if [[ "$result" == *"DENY"* ]]; then
     echo
     echo $INVALID_ORG_POLICY_IPFORWARD
+    echo
+    exit 1
+  fi
+
+  result=$(gcloud beta resource-manager org-policies describe compute.trustedImageProjects --project=$PROJECT_ID --effective)
+  if [[ "$result" == *"DENY"* ]]; then
+    echo
+    echo $INVALID_ORG_POLICY_TRUSTED_IMAGES
     echo
     exit 1
   fi
@@ -104,9 +105,17 @@ function check_deployment_does_not_exist {
     echo $DEPLOYMENT_ALREADY_EXISTS
     echo
     exit 1
-  else
-    echo "PASS: Anthos Sample Deployment does not already exist."
   fi
+
+  result=$(gcloud container clusters list --format=json --filter=name:anthos-sample-cluster2)
+  if [[ "$result" == *"anthos-sample-cluster"* ]]; then
+    echo
+    echo $DEPLOYMENT_ALREADY_EXISTS
+    echo
+    exit 1
+  fi
+
+  echo "PASS: Anthos Sample Deployment does not already exist."
 }
 
 function check_project_id_is_valid {
@@ -125,4 +134,3 @@ check_org_policy_is_valid
 check_service_management_api_is_enabled
 check_deployment_does_not_exist
 check_project_id_is_valid
-enable_compute_api

--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -eu
-
 # This script checks that prerequisites exist to ensure that
 # the Anthos Sample Deployment is successfully deployed.
 #
@@ -27,7 +25,7 @@ INVALID_ORG_POLICY_IPFORWARD="{
 }"
 
 INVALID_ORG_POLICY_TRUSTED_IMAGES="{
-  'KnownIssueId': 'invalid_org_policy_vmCanIpForward)',
+  'KnownIssueId': 'invalid_org_policy_trustedImageProjects)',
   'Message': 'An org policy (constraints/compute.trustedImageProjects) exists that will prevent this deployment.  Please try this deployment in a project without this org policy.'
 }"
 
@@ -57,6 +55,11 @@ function check_iam_policy {
 }
 
 function check_org_policy_is_valid {
+  if ! gcloud beta resource-manager org-policies list --project=$PROJECT_ID; then
+    echo "WARNING: Unable to verify if the project has any Organization Policies that will prevent the deployment."
+    return
+  fi
+
   result=$(gcloud beta resource-manager org-policies describe compute.requireOsLogin --project=$PROJECT_ID --effective)
   if [[ "$result" == *"enforced: true"* ]]; then
     echo


### PR DESCRIPTION
Update the prerequisite script to: add check for trusted images org policy, fix the failing org policy checks if user doesn't have access (fail right away), remove the commands to enable Compute Engine API (no longer needed), updated IAM policy check for creating the SA so it actually works, update existing deployment check to add the 2nd cluster.