### PR TITLE
sync the content from onlineboutique repo

### DIFF
--- a/config-repo/namespaces/istio-system/peer-authentication.yaml
+++ b/config-repo/namespaces/istio-system/peer-authentication.yaml
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kind: Cluster
-apiVersion: clusterregistry.k8s.io/v1alpha1
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
 metadata:
-  name: anthos-sample-cluster1
-  labels:
-    environment: asm
+  name: "default"
+  namespace: "istio-system"
+spec:
+  mtls:
+    mode: PERMISSIVE

--- a/config-repo/namespaces/onlineboutique/k8s-manifest.yaml
+++ b/config-repo/namespaces/onlineboutique/k8s-manifest.yaml
@@ -52,7 +52,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -120,7 +120,7 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 30m
+              cpu: 10m
               memory: 64Mi
             limits:
               cpu: 200m
@@ -179,7 +179,7 @@ spec:
           value: "False"
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 220Mi
           limits:
             cpu: 200m
@@ -260,7 +260,7 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 30m
+              cpu: 10m
               memory: 64Mi
             limits:
               cpu: 200m
@@ -309,7 +309,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -367,7 +367,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -414,7 +414,7 @@ spec:
           value: "0.0.0.0"
         resources:
           requests:
-            cpu: 50m
+            cpu: 15m
             memory: 64Mi
           limits:
             cpu: 300m
@@ -470,7 +470,7 @@ spec:
           value: "3"
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 128Mi
           limits:
             cpu: 200m
@@ -513,7 +513,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -570,7 +570,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 30m
+            cpu: 10m
             memory: 64Mi
           limits:
             cpu: 200m
@@ -623,7 +623,7 @@ spec:
             memory: 256Mi
             cpu: 125m
           requests:
-            cpu: 20m
+            cpu: 10m
             memory: 200Mi
       volumes:
       - name: redis-data
@@ -672,7 +672,7 @@ spec:
         #  value: "jaeger-collector:14268"
         resources:
           requests:
-            cpu: 40m
+            cpu: 15m
             memory: 180Mi
           limits:
             cpu: 300m


### PR DESCRIPTION
Sync the recent changes from onlineboutique repo, because:
* Users have expectation to find the source files in this repo, and are usually unaware of onlineboutique repo. For example https://github.com/GoogleCloudPlatform/anthos-sample-deployment/issues/17 and https://github.com/GoogleCloudPlatform/anthos-sample-deployment/issues/21
* We can use ASD repo as the source of repo files in future