### PR TITLE
Update frontend service type to ClusterIP

### DIFF
--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -88,7 +88,6 @@ kind: Service
 metadata:
   name: frontend
 spec:
-  type: LoadBalancer
   selector:
     app: frontend
   ports:


### PR DESCRIPTION
Update frontend service type from `LoadBalancer` to `ClusterIP` which is the default, in order to remove unnecessary external load balancer and adhere to ASM best-practice.


---------

Testing results:

![image](https://user-images.githubusercontent.com/2538581/100827396-8de17080-3497-11eb-8c6f-df743845db33.png)

![image](https://user-images.githubusercontent.com/2538581/100827170-16abdc80-3497-11eb-8479-088c8a567e67.png)
