### PR TITLE
Reduce cpu resource request

### DIFF
--- a/config-repo/namespaces/boa/accounts-db.yaml
+++ b/config-repo/namespaces/boa/accounts-db.yaml
@@ -48,7 +48,7 @@ spec:
             name: postgredb
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 128Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/balance-reader.yaml
+++ b/config-repo/namespaces/boa/balance-reader.yaml
@@ -67,7 +67,7 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 512Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/contacts.yaml
+++ b/config-repo/namespaces/boa/contacts.yaml
@@ -52,7 +52,7 @@ spec:
             name: accounts-db-config
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 64Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -70,7 +70,7 @@ spec:
           timeoutSeconds: 10
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 64Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -88,7 +88,6 @@ kind: Service
 metadata:
   name: frontend
 spec:
-  type: LoadBalancer
   selector:
     app: frontend
   ports:

--- a/config-repo/namespaces/boa/ledger-db.yaml
+++ b/config-repo/namespaces/boa/ledger-db.yaml
@@ -42,7 +42,7 @@ spec:
                 name: demo-data-config
           resources:
             requests:
-              cpu: 50m
+              cpu: 30m
               memory: 512Mi
             limits:
               cpu: 500m

--- a/config-repo/namespaces/boa/ledger-writer.yaml
+++ b/config-repo/namespaces/boa/ledger-writer.yaml
@@ -63,7 +63,7 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 512Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/loadgenerator.yaml
+++ b/config-repo/namespaces/boa/loadgenerator.yaml
@@ -43,7 +43,7 @@ spec:
           value: "error"
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 512Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/transaction-history.yaml
+++ b/config-repo/namespaces/boa/transaction-history.yaml
@@ -72,7 +72,7 @@ spec:
             name: ledger-db-config
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 512Mi
           limits:
             cpu: 500m

--- a/config-repo/namespaces/boa/userservice.yaml
+++ b/config-repo/namespaces/boa/userservice.yaml
@@ -65,7 +65,7 @@ spec:
           timeoutSeconds: 10
         resources:
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 64Mi
           limits:
             cpu: 500m


### PR DESCRIPTION
Reduce CPU resource request, so that they can fit on 3 x 2 vCPUs cluster with default (larger) ASM CPU resource requests, for the next generation of Anthos Sample Deployment.

Additional rationale is documented at internal bug ID 173169489. If there are any comments / questions on this PR, please also post in the internal bug.
