### PR TITLE
Skip quota check and display a warning if compute API is not enabled

### DIFF
--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -163,7 +163,7 @@ function check_project_id_is_valid {
 function check_quota_is_sufficient {
   api=$(gcloud services list --format=json --filter=name:$COMPUTE_API)
   if [[ "$api" != *"$COMPUTE_API"* ]]; then
-    echo "WARNING: Unable to verify compute quota because $COMPUTE_API in project $PROJECT_ID is not enabled. Enable this API in the current project at https://console.cloud.google.com/apis/api/compute.googleapis.com/overview?project=$PROJECT_ID, and run this script again."
+    echo "WARNING: Unable to verify compute quota because $COMPUTE_API in project $PROJECT_ID is not enabled. Enable this API in the current project at https://console.cloud.google.com/apis/api/compute.googleapis.com/overview?project=$PROJECT_ID and run this script again."
     return
   fi
 

--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -7,6 +7,7 @@
 # ./asd-prereq-checker.sh
 
 SERVICE_MANAGEMENT_API=servicemanagement.googleapis.com
+COMPUTE_API=compute.googleapis.com
 PROJECT_ID=$(gcloud config get-value project 2> /dev/null)
 ZONE=$(gcloud config get-value compute/zone 2> /dev/null)
 if [[ -z "${ZONE}" ]]; then
@@ -160,6 +161,12 @@ function check_project_id_is_valid {
 
 
 function check_quota_is_sufficient {
+  api=$(gcloud services list --format=json --filter=name:$COMPUTE_API)
+  if [[ "$api" != *"$COMPUTE_API"* ]]; then
+    echo "WARNING: Unable to verify compute quota because $COMPUTE_API in project $PROJECT_ID is not enabled. Please run 'gcloud services enable $COMPUTE_API' before running this script again."
+    return
+  fi
+
   quota=$(gcloud compute regions describe ${REGION} --flatten quotas --format="csv(quotas.metric,quotas.limit,quotas.usage)"|egrep '^CPUS,')
   limit=$(echo $quota | awk -F, '{print $2}' | awk -F. '{print $1}' )
   usage=$(echo $quota | awk -F, '{print $3}' | awk -F. '{print $1}' )

--- a/bin/asd-prereq-checker.sh
+++ b/bin/asd-prereq-checker.sh
@@ -163,7 +163,7 @@ function check_project_id_is_valid {
 function check_quota_is_sufficient {
   api=$(gcloud services list --format=json --filter=name:$COMPUTE_API)
   if [[ "$api" != *"$COMPUTE_API"* ]]; then
-    echo "WARNING: Unable to verify compute quota because $COMPUTE_API in project $PROJECT_ID is not enabled. Please run 'gcloud services enable $COMPUTE_API' before running this script again."
+    echo "WARNING: Unable to verify compute quota because $COMPUTE_API in project $PROJECT_ID is not enabled. Enable this API in the current project at https://console.cloud.google.com/apis/api/compute.googleapis.com/overview?project=$PROJECT_ID, and run this script again."
     return
   fi
 


### PR DESCRIPTION
The purpose of this change is to avoid the below interactive prompt which users will get when prereq script is run before Compute API is enabled.
```
API [compute.googleapis.com] not enabled on project [xxx].
Would you like to enable and retry (this will take a few minutes)?
(y/N)?
```
Considerations:
* It's better to keep the pre-req check script non-instructive (as its name suggests) and not attempt to make any changes (with prompt or without) to the customer's project as part of this script.
* If Compute API is not enabled, most likely there are no compute resources in the project at all and the project is expected to pass quota check once compute API is enabled. Hence this is a WARNING and not an ERROR for quota check.
* The tutorial has been updated to prompt user to enable the Compute API before running this script. 
* When launching the Marketplace solution, the Marketplace will also implicitly enable Compute API in the background before allowing user to start the deployment. Hence from UX perspective I tend not to add Compute API as an additional prereq check in this script that will fail with an ERROR and a "must do" manual task, and prefer to just prompt with a softer WARNING and an optional task instead.