### PR TITLE
Add git init helper function

### DIFF
--- a/bin/init-anthos-sample-deployment.env
+++ b/bin/init-anthos-sample-deployment.env
@@ -109,8 +109,8 @@ kubectl config use-context "${names[0]}"
 
 # tutorial helper function to configure git user and name
 function init_git {
-  git_name=$(git config --get user.name)
   git_email=$(git config --get user.email)
+  git_name=$(git config --get user.name)
   user_email=$(gcloud config list account --format "value(core.account)")
   user_name=$(echo $user_email | cut -f1 -d"@")
 

--- a/bin/init-anthos-sample-deployment.env
+++ b/bin/init-anthos-sample-deployment.env
@@ -30,6 +30,10 @@ function precheck {
     error "Kubectl not installed, you can run the following command to install it:\n\nsudo apt-get install kubectl"
   )
 
+  command -v git || (
+    error "git not installed, you can run the following command to install it:\n\nsudo apt-get install git"
+  )
+
   PROJECT=$(gcloud config get-value project)
   if [[ -z ${PROJECT} ]]; then
     error "Failed to find project, please use 'gcloud config set project PROJECT_ID' to select the right project."
@@ -102,6 +106,27 @@ names=($(kubectl config get-contexts -o name))
 
 # use first context by default
 kubectl config use-context "${names[0]}"
+
+# tutorial helper function to configure git user and name
+function init_git {
+  git_name=$(git config --get user.name)
+  git_email=$(git config --get user.email)
+  user_email=$(gcloud config list account --format "value(core.account)")
+  user_name=$(echo $user_email | cut -f1 -d"@")
+
+  if [[ -z "$git_email" ]]; then
+    git config --local  user.email $user_email
+    info "Configured local git user.email to $user_email"
+  else
+    info "Verified git user.email has been set to $git_email"
+  fi
+  if [[ -z "$git_name" ]]; then
+    git config --local  user.name $user_name
+    info "Configured local git user.name to $user_name"
+  else
+    info "Verified git user.name has been set to $git_name"
+  fi
+}
 
 # tutorial helper function to watch nomos sync clusters
 function watchmtls {


### PR DESCRIPTION
This is to handle the situation when user.email and user.name configs are not set in git.

The intention is to let the user run `init_git` in this part of the tutorial: https://cloud.google.com/anthos/docs/tutorials/security#anthos-config-management-setup.

Internal Bug ID: 156982664