### PR TITLE
Update asm version in init script

### DIFF
--- a/bin/init-anthos-sample-deployment.env
+++ b/bin/init-anthos-sample-deployment.env
@@ -58,8 +58,8 @@ function install_istioctl {
   fi
 
   mkdir -p "${HOME}/bin"
-  local ver=1.4.7-asm.0
-  gsutil cat gs://gke-release/asm/istio-${ver}-linux.tar.gz | tar -C ${HOME}/bin/ -z -x istio-${ver}/bin/istioctl --strip-components=2
+  local ver=1.8.1-asm.5
+  gsutil cat gs://gke-release/asm/istio-${ver}-linux-amd64.tar.gz | tar -C ${HOME}/bin/ -z -x istio-${ver}/bin/istioctl --strip-components=2
 }
 
 function install_nomos {


### PR DESCRIPTION
We wouldn't need to download `istioctl` if user runs this on Cloud Shell now. But updating the version just in case user wants to run it on other Debian machines.