### PR TITLE
Update BoA version to v0.5.2

### DIFF
--- a/config-repo/namespaces/boa/accounts-db.yaml
+++ b/config-repo/namespaces/boa/accounts-db.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos/accounts-db:v0.3.0
+        image: gcr.io/bank-of-anthos/accounts-db:v0.5.2
         envFrom:
           - configMapRef:
               name: environment-config

--- a/config-repo/namespaces/boa/accounts-db.yaml
+++ b/config-repo/namespaces/boa/accounts-db.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: accounts-db
-        image: gcr.io/bank-of-anthos/accounts-db:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.2
         envFrom:
           - configMapRef:
               name: environment-config

--- a/config-repo/namespaces/boa/accounts-db.yaml
+++ b/config-repo/namespaces/boa/accounts-db.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config-repo/namespaces/boa/balance-reader.yaml
+++ b/config-repo/namespaces/boa/balance-reader.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ spec:
           value: "8080"
         # toggle Cloud Trace export
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         - name: ENABLE_METRICS
-          value: "true"
+          value: "false"
         - name: POLL_MS
           value: "100"
         - name: CACHE_SIZE

--- a/config-repo/namespaces/boa/balance-reader.yaml
+++ b/config-repo/namespaces/boa/balance-reader.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/config-repo/namespaces/boa/balance-reader.yaml
+++ b/config-repo/namespaces/boa/balance-reader.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: balancereader
-        image: gcr.io/bank-of-anthos/balancereader:v0.3.0
+        image: gcr.io/bank-of-anthos/balancereader:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         # toggle Cloud Trace export

--- a/config-repo/namespaces/boa/balance-reader.yaml
+++ b/config-repo/namespaces/boa/balance-reader.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,9 +41,9 @@ spec:
           value: "8080"
         # toggle Cloud Trace export
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         - name: ENABLE_METRICS
-          value: "false"
+          value: "true"
         - name: POLL_MS
           value: "100"
         - name: CACHE_SIZE

--- a/config-repo/namespaces/boa/config.yaml
+++ b/config-repo/namespaces/boa/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config-repo/namespaces/boa/contacts.yaml
+++ b/config-repo/namespaces/boa/contacts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         # Valid levels are debug, info, warning, error, critical.
         # If no valid level is set, will default to info.
         - name: LOG_LEVEL

--- a/config-repo/namespaces/boa/contacts.yaml
+++ b/config-repo/namespaces/boa/contacts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         # Valid levels are debug, info, warning, error, critical.
         # If no valid level is set, will default to info.
         - name: LOG_LEVEL

--- a/config-repo/namespaces/boa/contacts.yaml
+++ b/config-repo/namespaces/boa/contacts.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/config-repo/namespaces/boa/contacts.yaml
+++ b/config-repo/namespaces/boa/contacts.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: contacts
-        image: gcr.io/bank-of-anthos/contacts:v0.3.0
+        image: gcr.io/bank-of-anthos/contacts:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/config-repo/namespaces/boa/frontend-ingress.yaml
+++ b/config-repo/namespaces/boa/frontend-ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config-repo/namespaces/boa/frontend-ingress.yaml
+++ b/config-repo/namespaces/boa/frontend-ingress.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -40,7 +40,7 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         - name: SCHEME
           value: "http"
          # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,12 +40,18 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         - name: SCHEME
           value: "http"
          # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
         - name: LOG_LEVEL
           value: "info"
+        # Set to "true" to enable the CymbalBank logo + title
+        # - name: CYMBAL_LOGO
+        #   value: "false"
+        # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
+        # - name: BANK_NAME
+        #   value: ""
         - name: DEFAULT_USERNAME
           valueFrom:
             configMapKeyRef:
@@ -68,6 +74,13 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
         resources:
           requests:
             cpu: 30m
@@ -88,6 +101,7 @@ kind: Service
 metadata:
   name: frontend
 spec:
+  type: LoadBalancer
   selector:
     app: frontend
   ports:

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/config-repo/namespaces/boa/frontend.yaml
+++ b/config-repo/namespaces/boa/frontend.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: front
-        image: gcr.io/bank-of-anthos/frontend:v0.3.0
+        image: gcr.io/bank-of-anthos/frontend:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/config-repo/namespaces/boa/ledger-db.yaml
+++ b/config-repo/namespaces/boa/ledger-db.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config-repo/namespaces/boa/ledger-db.yaml
+++ b/config-repo/namespaces/boa/ledger-db.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos/ledger-db:v0.5.2
+          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.2
           ports:
             - containerPort: 5432
           envFrom:

--- a/config-repo/namespaces/boa/ledger-db.yaml
+++ b/config-repo/namespaces/boa/ledger-db.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: postgres
-          image: gcr.io/bank-of-anthos/ledger-db:v0.3.0
+          image: gcr.io/bank-of-anthos/ledger-db:v0.5.2
           ports:
             - containerPort: 5432
           envFrom:

--- a/config-repo/namespaces/boa/ledger-db.yaml
+++ b/config-repo/namespaces/boa/ledger-db.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config-repo/namespaces/boa/ledger-writer.yaml
+++ b/config-repo/namespaces/boa/ledger-writer.yaml
@@ -40,9 +40,9 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         - name: ENABLE_METRICS
-          value: "true"
+          value: "false"
          # tell Java to obey container memory limits
         - name: JVM_OPTS
           value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/config-repo/namespaces/boa/ledger-writer.yaml
+++ b/config-repo/namespaces/boa/ledger-writer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         - name: ENABLE_METRICS
-          value: "false"
+          value: "true"
          # tell Java to obey container memory limits
         - name: JVM_OPTS
           value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"

--- a/config-repo/namespaces/boa/ledger-writer.yaml
+++ b/config-repo/namespaces/boa/ledger-writer.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:v0.3.0
+        image: gcr.io/bank-of-anthos/ledgerwriter:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/config-repo/namespaces/boa/ledger-writer.yaml
+++ b/config-repo/namespaces/boa/ledger-writer.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: ledgerwriter
-        image: gcr.io/bank-of-anthos/ledgerwriter:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/config-repo/namespaces/boa/loadgenerator.yaml
+++ b/config-repo/namespaces/boa/loadgenerator.yaml
@@ -33,7 +33,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.2
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/config-repo/namespaces/boa/loadgenerator.yaml
+++ b/config-repo/namespaces/boa/loadgenerator.yaml
@@ -33,7 +33,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: loadgenerator
-        image: gcr.io/bank-of-anthos/loadgenerator:v0.3.0
+        image: gcr.io/bank-of-anthos/loadgenerator:v0.5.2
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/config-repo/namespaces/boa/loadgenerator.yaml
+++ b/config-repo/namespaces/boa/loadgenerator.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config-repo/namespaces/boa/transaction-history.yaml
+++ b/config-repo/namespaces/boa/transaction-history.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"

--- a/config-repo/namespaces/boa/transaction-history.yaml
+++ b/config-repo/namespaces/boa/transaction-history.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         - name: ENABLE_METRICS
-          value: "true"
+          value: "false"
         - name: POLL_MS
           value: "100"
         - name: CACHE_SIZE

--- a/config-repo/namespaces/boa/transaction-history.yaml
+++ b/config-repo/namespaces/boa/transaction-history.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         - name: ENABLE_METRICS
-          value: "false"
+          value: "true"
         - name: POLL_MS
           value: "100"
         - name: CACHE_SIZE

--- a/config-repo/namespaces/boa/transaction-history.yaml
+++ b/config-repo/namespaces/boa/transaction-history.yaml
@@ -29,14 +29,14 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: transactionhistory
-        image: gcr.io/bank-of-anthos/transactionhistory:v0.3.0
+        image: gcr.io/bank-of-anthos/transactionhistory:v0.5.2
         volumeMounts:
         - name: publickey
           mountPath: "/root/.ssh"
           readOnly: true
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/config-repo/namespaces/boa/userservice.yaml
+++ b/config-repo/namespaces/boa/userservice.yaml
@@ -43,7 +43,7 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "true"
+          value: "false"
         - name: TOKEN_EXPIRY_SECONDS
           value: "3600"
         - name: PRIV_KEY_PATH

--- a/config-repo/namespaces/boa/userservice.yaml
+++ b/config-repo/namespaces/boa/userservice.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ spec:
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING
-          value: "false"
+          value: "true"
         - name: TOKEN_EXPIRY_SECONDS
           value: "3600"
         - name: PRIV_KEY_PATH

--- a/config-repo/namespaces/boa/userservice.yaml
+++ b/config-repo/namespaces/boa/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:v0.3.0
+        image: gcr.io/bank-of-anthos/userservice:v0.5.2
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"
@@ -39,7 +39,7 @@ spec:
           containerPort: 8080
         env:
         - name: VERSION
-          value: "v0.3.0"
+          value: "v0.5.2"
         - name: PORT
           value: "8080"
         - name: ENABLE_TRACING

--- a/config-repo/namespaces/boa/userservice.yaml
+++ b/config-repo/namespaces/boa/userservice.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: userservice
-        image: gcr.io/bank-of-anthos/userservice:v0.5.2
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.2
         volumeMounts:
         - name: keys
           mountPath: "/root/.ssh"


### PR DESCRIPTION
Update to Bank of Anthos v0.5.2 for log4j patches

* Updated manifests are copied from https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/master/kubernetes-manifests and https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/master/istio-manifests
* We need to keep the original cpu request customization so that it can fit on a smaller cluster.